### PR TITLE
Small Typo on file path

### DIFF
--- a/scripts/generateEmbedCss.js
+++ b/scripts/generateEmbedCss.js
@@ -10,5 +10,5 @@ const templatePath = require.resolve('./embedCssTemplate.js')
 let foo = fs.readFileSync(templatePath,  'utf-8');
 foo = foo.replace('_CSS_', ping);
 
-const outputPath = require.resolve('../js/embedCss.js')
+const outputPath = require.resolve('../js/embedCSS.js')
 fs.writeFileSync(outputPath, foo,  'utf-8');


### PR DESCRIPTION
On an OS with file name sensitive system - `embedCss.css` was not able to be located - instead, fixed it to a file path that would work on all os - `embedCSS.css`