### PR TITLE
Alert Dialog Settings

### DIFF
--- a/dist/igv-ui.js
+++ b/dist/igv-ui.js
@@ -442,7 +442,18 @@ const httpMessages =
 
 
 class AlertDialog {
-    constructor(parent) {
+    /**
+     * Initialize a new alert dialog
+     * @param parent
+     * @param alertProps - Optional - properties such as scroll to error
+     */
+    constructor(parent, alertProps) {
+        this.alertProps = {
+            /** When an alert is presented - focus occur */
+            shouldFocus: true,
+            /** When focus occur - scroll into that element in the view */
+            preventScroll:false,
+            ...alertProps};
 
         // container
         this.container = div({class: "igv-ui-alert-dialog-container"});
@@ -517,7 +528,11 @@ class AlertDialog {
         this.body.innerHTML = string;
         this.callback = callback;
         show(this.container);
-        this.container.focus();
+        if (this.alertProps.shouldFocus) {
+            this.container.focus(
+                { preventScroll: this.alertProps.preventScroll }
+            );
+        }
     }
 }
 
@@ -547,9 +562,9 @@ let alertDialog;
 
 const Alert = {
 
-    init(root) {
+    init(root, settings) {
         if (!alertDialog) {
-            alertDialog = new AlertDialog(root);
+            alertDialog = new AlertDialog(root, settings);
         }
     },
 

--- a/dist/igv-ui.js
+++ b/dist/igv-ui.js
@@ -447,7 +447,7 @@ class AlertDialog {
      * @param parent
      * @param alertProps - Optional - properties such as scroll to error
      */
-    constructor(parent, alertProps) {
+    constructor(parent, alertProps={}) {
         this.alertProps = {
             /** When an alert is presented - focus occur */
             shouldFocus: true,
@@ -562,10 +562,8 @@ let alertDialog;
 
 const Alert = {
 
-    init(root, settings) {
-        if (!alertDialog) {
-            alertDialog = new AlertDialog(root, settings);
-        }
+    init(root, config={}) {
+	    alertDialog = new AlertDialog(root, config);
     },
 
     presentAlert (alert, callback) {

--- a/dist/igv-ui.js
+++ b/dist/igv-ui.js
@@ -447,13 +447,13 @@ class AlertDialog {
      * @param parent
      * @param alertProps - Optional - properties such as scroll to error
      */
-    constructor(parent, alertProps={}) {
-        this.alertProps = {
+    constructor(parent, alertProps) {
+        this.alertProps = Object.assign({
             /** When an alert is presented - focus occur */
             shouldFocus: true,
             /** When focus occur - scroll into that element in the view */
-            preventScroll:false,
-            ...alertProps};
+            preventScroll: false
+        }, alertProps);
 
         // container
         this.container = div({class: "igv-ui-alert-dialog-container"});

--- a/js/alert.js
+++ b/js/alert.js
@@ -6,9 +6,13 @@ let alertDialog
 
 const Alert = {
 
-    init(root, settings) {
+    init(root, config) {
         if (!alertDialog) {
-            alertDialog = new AlertDialog(root, settings);
+	    let alertConfig = {};
+            if(config && config.alert) {
+                alertConfig = config.alert
+            }
+            alertDialog = new AlertDialog(root, alertConfig);
         }
     },
 

--- a/js/alert.js
+++ b/js/alert.js
@@ -6,14 +6,8 @@ let alertDialog
 
 const Alert = {
 
-    init(root, config) {
-        if (!alertDialog) {
-	    let alertConfig = {};
-            if(config && config.alert) {
-                alertConfig = config.alert
-            }
-            alertDialog = new AlertDialog(root, alertConfig);
-        }
+    init(root, config={}) {
+	    alertDialog = new AlertDialog(root, config);
     },
 
     presentAlert (alert, callback) {

--- a/js/alert.js
+++ b/js/alert.js
@@ -6,9 +6,9 @@ let alertDialog
 
 const Alert = {
 
-    init(root) {
+    init(root, settings) {
         if (!alertDialog) {
-            alertDialog = new AlertDialog(root);
+            alertDialog = new AlertDialog(root, settings);
         }
     },
 

--- a/js/components/alertDialog.js
+++ b/js/components/alertDialog.js
@@ -10,7 +10,18 @@ const httpMessages =
 
 
 class AlertDialog {
-    constructor(parent) {
+    /**
+     * Initialize a new alert dialog
+     * @param parent
+     * @param alertProps - Optional - properties such as scroll to error
+     */
+    constructor(parent, alertProps) {
+        this.alertProps = {
+            /** When an alert is presented - focus occur */
+            shouldFocus: true,
+            /** When focus occur - scroll into that element in the view */
+            preventScroll:false,
+            ...alertProps};
 
         // container
         this.container = DOMUtils.div({class: "igv-ui-alert-dialog-container"});
@@ -85,7 +96,11 @@ class AlertDialog {
         this.body.innerHTML = string
         this.callback = callback
         DOMUtils.show(this.container, "flex")
-        this.container.focus()
+        if (this.alertProps.shouldFocus) {
+            this.container.focus(
+                { preventScroll: this.alertProps.preventScroll }
+            )
+        }
     }
 }
 

--- a/js/components/alertDialog.js
+++ b/js/components/alertDialog.js
@@ -15,7 +15,7 @@ class AlertDialog {
      * @param parent
      * @param alertProps - Optional - properties such as scroll to error
      */
-    constructor(parent, alertProps) {
+    constructor(parent, alertProps={}) {
         this.alertProps = {
             /** When an alert is presented - focus occur */
             shouldFocus: true,

--- a/js/components/alertDialog.js
+++ b/js/components/alertDialog.js
@@ -15,13 +15,13 @@ class AlertDialog {
      * @param parent
      * @param alertProps - Optional - properties such as scroll to error
      */
-    constructor(parent, alertProps={}) {
-        this.alertProps = {
+    constructor(parent, alertProps) {
+        this.alertProps = Object.assign({
             /** When an alert is presented - focus occur */
             shouldFocus: true,
             /** When focus occur - scroll into that element in the view */
-            preventScroll:false,
-            ...alertProps};
+            preventScroll: false
+        }, alertProps);
 
         // container
         this.container = DOMUtils.div({class: "igv-ui-alert-dialog-container"});


### PR DESCRIPTION
# Impelements
Added support for `Alert Dialog` settings:
The included settings are:
* `shouldFocus` - When an alert is presented - focus / don't do anything
* `preventScroll` - On focus occur - scroll into the alert container element in the browsers view

This fixes #43 - In our case - if we embed `igv` as part of a larger page. In that case, we want to be able to control if focusing (and especially scrolling) happens.

# Testing
1. I've added to the examples new dialog - Clicked on alert and saw that indeed it's focusing.
2. I've tested that older dialog without settings works as expected (Regression)

# Things to notice
The [Rest/Spread](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax) Properties that we are using to override the default setting are supported by all major browsers (except IE) as noted [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#browser_compatibility) - if we want IE support we can replace this with `Object.assign`